### PR TITLE
Challenge 4: request collapsing with AKKA

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -375,7 +375,8 @@ of just sharing the results we share the ongoing calculation of a result.
 
 | Java
 | http://doc.akka.io/docs/akka/2.4/java/index-actors.html[akka (actors)]
-|
+| link:./src/main/java/challenge4/akka_actor/CollapsingWithAkka.java[]
+
 
 | Java
 | http://vertx.io/docs/vertx-core/java/[Vert.x]

--- a/src/main/java/challenge4/akka_actor/CollapsingWithAkka.java
+++ b/src/main/java/challenge4/akka_actor/CollapsingWithAkka.java
@@ -1,0 +1,97 @@
+package challenge4.akka_actor;
+
+import akka.actor.AbstractActor;
+import akka.actor.ActorRef;
+import akka.actor.ActorSystem;
+import akka.actor.Props;
+import akka.japi.pf.ReceiveBuilder;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
+import externalLegacyCodeNotUnderOurControl.PriceService;
+import scala.concurrent.duration.Duration;
+
+import java.util.concurrent.TimeUnit;
+
+import static externalLegacyCodeNotUnderOurControl.PrintlnWithThreadname.println;
+import static java.lang.Thread.sleep;
+
+/**
+ * Collapse _equal_ requests when sending to the {@link PriceServiceActor}.
+ * <pre>
+ * [current "book" price?] ->                    -> [println "book" price]
+ *                            \                  /
+ * [current "book" price?] -> [PriceService1::getPrice]  -> [println "book" price]
+ *
+ * </pre>
+ */
+public class CollapsingWithAkka {
+
+    public static void main(String[] args) throws Exception {
+        ActorSystem system = ActorSystem.create("MySystem");
+
+        final ActorRef priceServiceActor = system.actorOf(Props.create(PriceServiceActor.class, new PriceService(4)));
+        final ActorRef priceFacade = system.actorOf(Props.create(PriceFacade.class, priceServiceActor));
+        final ActorRef bookSimulator = system.actorOf(Props.create(ClientSimulator.class, priceFacade, "Book"));
+        final ActorRef toySimulator = system.actorOf(Props.create(ClientSimulator.class, priceFacade, "Toy"));
+
+        sleep(10_000);
+        system.shutdown();
+        println("Main thread done.");
+    }
+
+    /**
+     * Collapses {@link PriceRequest}s and returns the same result to all requesters for the same product.
+     */
+    private static class PriceFacade extends AbstractActor {
+        Multimap<PriceRequest, ActorRef> requesters = ArrayListMultimap.create();
+
+        public PriceFacade(ActorRef priceServiceActor) {
+            receive(ReceiveBuilder.
+                    match(PriceRequest.class, request -> {
+                        println("PriceFacade: " + request);
+                        boolean firstRequest = !requesters.containsKey(request);
+                        requesters.put(request, sender());
+                        if (firstRequest) {
+                            priceServiceActor.tell(request, self());
+                        }
+                    }).
+                    match(PriceEnvelope.class, priceEnvelope -> {
+                        println("PriceFacade: response: " + priceEnvelope);
+                        for (ActorRef requester : requesters.removeAll(priceEnvelope.priceRequest)) {
+                            requester.tell(priceEnvelope.price, self());
+                        }
+                    }).
+                    build()
+            );
+        }
+    }
+
+    /**
+     * There is one simulator per Product, which sends requesters regularly.
+     */
+    public static class ClientSimulator extends AbstractActor {
+        private ActorRef priceFacade;
+        private String productName;
+
+        public ClientSimulator(ActorRef priceFacade, String productName) {
+            this.priceFacade = priceFacade;
+            this.productName = productName;
+            receive(ReceiveBuilder.
+                    match(Price.class, price -> {
+                        println("ClientSimulator " + productName + ": " + price);
+                    }).
+                    build());
+        }
+
+        @Override
+        public void preStart() throws Exception {
+            PriceRequest request = new PriceRequest(productName);
+            context().system().scheduler().schedule(Duration.Zero(),
+                    Duration.create(1, TimeUnit.SECONDS),
+                    priceFacade, request,
+                    context().system().dispatcher(), self());
+        }
+    }
+}
+
+

--- a/src/main/java/challenge4/akka_actor/Price.java
+++ b/src/main/java/challenge4/akka_actor/Price.java
@@ -1,0 +1,16 @@
+package challenge4.akka_actor;
+
+class Price {
+    public final int amount;
+
+    public Price(int amount) {
+        this.amount = amount;
+    }
+
+    @Override
+    public String toString() {
+        return "Price{" +
+                "amount=" + amount +
+                '}';
+    }
+}

--- a/src/main/java/challenge4/akka_actor/PriceEnvelope.java
+++ b/src/main/java/challenge4/akka_actor/PriceEnvelope.java
@@ -1,5 +1,8 @@
 package challenge4.akka_actor;
 
+/**
+ * Contains service request and response in order to map them.
+ */
 class PriceEnvelope {
     public final PriceRequest priceRequest;
     public final Price price;

--- a/src/main/java/challenge4/akka_actor/PriceEnvelope.java
+++ b/src/main/java/challenge4/akka_actor/PriceEnvelope.java
@@ -1,0 +1,19 @@
+package challenge4.akka_actor;
+
+class PriceEnvelope {
+    public final PriceRequest priceRequest;
+    public final Price price;
+
+    public PriceEnvelope(PriceRequest priceRequest, Price price) {
+        this.priceRequest = priceRequest;
+        this.price = price;
+    }
+
+    @Override
+    public String toString() {
+        return "PriceEnvelope{" +
+                "priceRequest=" + priceRequest +
+                ", price=" + price +
+                '}';
+    }
+}

--- a/src/main/java/challenge4/akka_actor/PriceRequest.java
+++ b/src/main/java/challenge4/akka_actor/PriceRequest.java
@@ -1,0 +1,31 @@
+package challenge4.akka_actor;
+
+import java.util.Objects;
+
+class PriceRequest {
+    private String productName;
+
+    public PriceRequest(String productName) {
+        this.productName = productName;
+    }
+
+    @Override
+    public String toString() {
+        return "PriceRequest{" +
+                "productName='" + productName + '\'' +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PriceRequest that = (PriceRequest) o;
+        return Objects.equals(productName, that.productName);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(productName);
+    }
+}

--- a/src/main/java/challenge4/akka_actor/PriceServiceActor.java
+++ b/src/main/java/challenge4/akka_actor/PriceServiceActor.java
@@ -1,0 +1,41 @@
+package challenge4.akka_actor;
+
+import akka.actor.AbstractActor;
+import akka.actor.ActorRef;
+import akka.dispatch.OnSuccess;
+import akka.japi.pf.ReceiveBuilder;
+import externalLegacyCodeNotUnderOurControl.PriceService;
+import scala.concurrent.Future;
+
+import static akka.dispatch.Futures.future;
+import static externalLegacyCodeNotUnderOurControl.PrintlnWithThreadname.println;
+
+/**
+ * Calls the price Service (blocking) and returns the result
+ */
+public class PriceServiceActor extends AbstractActor {
+
+    public PriceServiceActor(PriceService service) {
+
+        receive(ReceiveBuilder.
+                match(PriceRequest.class, (PriceRequest request) -> {
+                    println("PriceServiceActor: got price request: " + request);
+
+                    ActorRef sender = sender();
+                    Future<Price> calc = future(
+                            () -> new Price(service.getPrice()),
+                            context().system().dispatcher());
+
+                    calc.onSuccess(new OnSuccess<Price>() {
+                        @Override
+                        public void onSuccess(Price price) throws Throwable {
+                            println("PriceServiceActor: Success: " + price);
+                            sender.tell(new PriceEnvelope(request, price), self());
+                        }
+                    }, context().system().dispatcher());
+                }).
+                build()
+        );
+    }
+
+}


### PR DESCRIPTION
In my opinion the Challenge 4 definition is not practical enough. I only want to collapse requests about the same entity. Example: getPrice("toy") and getPrice("book") should obviously not collapse and not return the same price. 

So I wrote an "extended" solution with akka. 

Request for Comments 